### PR TITLE
fix: Do not try to break apart items that should be untinkered

### DIFF
--- a/release/scripts/ocd-cleanup.ash
+++ b/release/scripts/ocd-cleanup.ash
@@ -732,8 +732,6 @@ int ocd_control(boolean StopForMissingItems, string extraData) {
 			return false;
 		if(act_cat(make, "MAKE", "") && !check_inventory(StopForMissingItems))
 			return false;
-		if(act_cat(untink, "BREAK", "") && !check_inventory(StopForMissingItems))
-			return false;
 		if(act_cat(untink, "UNTN", "") && !check_inventory(StopForMissingItems))
 			return false;
 		if(act_cat(usex, "USE", "") && !check_inventory(StopForMissingItems))


### PR DESCRIPTION
Previously, OCD-Cleanup attempted to break apart (`BREAK` action) items that should be untinkered (`UNTN` action), before actually untinkering them. Since only 3 BRICKO items in existence ([BRICKO hat](https://kol.coldfront.net/thekolwiki/index.php/BRICKO_hat), [sword](https://kol.coldfront.net/thekolwiki/index.php/BRICKO_sword), and [pants](https://kol.coldfront.net/thekolwiki/index.php/BRICKO_pants)) can be broken apart, and none of them can be untinkered, this did nothing except wasting server hits.

This particular code (inherited from OCD Inventory Cleanup) appears to be a copy-paste error and should be removable without any ill effects.

Note: OCD-Cleanup correctly breaks apart items that should be broken apart in the first place--both before and after this fix.