### PR TITLE
Fix expected price for mall multi

### DIFF
--- a/release/scripts/ocd-cleanup.ash
+++ b/release/scripts/ocd-cleanup.ash
@@ -370,8 +370,8 @@ int ocd_control(boolean StopForMissingItems, string extraData) {
 				queue.append(", ");
 			queue.append(quant + " "+ it);
 			if(act == "MALL") {
+				price[it] = sale_price(it);
 				if(!use_multi) {
-					price[it] = sale_price(it);
 					if(getvar("BaleOCD_Pricing") == "auto")
 						queue.append(" @ "+ rnum(price[it]));
 				}


### PR DESCRIPTION
When sending `MALL` items to a mall multi, OCD-Cleanup previously displayed an incorrect "Sale price for this line:" message, usually with a price of zero. Fix this so that the script always shows the sum of expected sale prices.

Note: The expected sale price always uses the mall minimum (affected by the user-defined minimum OCD price), even if `BaleOCD_Pricing` is not set to `"auto"`.