### PR TITLE
fix: Load concoctions.txt from correct path

### DIFF
--- a/release/relay/relay_OCD-Cleanup_Manager.ash
+++ b/release/relay/relay_OCD-Cleanup_Manager.ash
@@ -232,7 +232,9 @@ item item_name(string doodad) {
 void set_craftable() {
 	typedef string[] type_c;
 	type_c [string] crafty;
-	file_to_map("concoctions.txt", crafty);
+	// Don't bother checking the return value of file_to_map().
+	// It returns `true` even if the file path is incorrect.
+	file_to_map("data/concoctions.txt", crafty);
 	foreach product, mix in crafty {
 		boolean method = true; // First item in a concoction is the method of crafting.
 		foreach x,it in mix {


### PR DESCRIPTION
Due to internal changes in KoLmafia's data file loading mechanism, the relay script (OCD Cleanup Manager) was silently failing to load `concoctions.txt`. This had been preventing the "Craft into a..." option from being offered for craftable items.

This is fixed by prepending `data/` to the file path.

The particular KoLmafia change *may* be [r20495](https://kolmafia.us/threads/20495-fixed-potential-security-issue.25614/) or [r20498](https://kolmafia.us/threads/20498-fix-restricted-access-to-some-files-since-r20495.25617/), or some other revision. Also see discussion regarding the bug and its workarounds:

- https://kolmafia.us/threads/wtf-relay-script-collection.15696/post-160540
- https://kolmafia.us/threads/can-no-longer-use-file_to_map-to-access-a-file-contained-in-the-kolmafia-jar.25704/