### PR TITLE
added LICENSE file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,6 @@
-All code submitted prior to 2020-12-22 belongs to balefull
-All code submitted after that date is released via MIT License as per below
+This project is a fork of https://sourceforge.net/projects/ocd.bale.p/
+All code submitted prior to 2020-12-22 is owned by Bale, under no specific license.
+All code submitted after that date is licensed under MIT License.
 
 MIT License
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,24 @@
+All code submitted prior to 2020-12-22 belongs to balefull
+All code submitted after that date is released via MIT License as per below
+
+MIT License
+
+Copyright (c) 2021 Loathing-Associates-Scripting-Society
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
makes LASS code submissions open source via MIT license

thus the only proprietary code is the original code by baleful. Making it so baleful is the only person who can legally shut down the project. (at the moment any person who ever submits code can do it. The more people join the project, the more at risk it is as each additional person is added to the list).

This change requires permission from current code submitters @Rinn and @pastelmind as both have submitted code that falls under this license change