### PR TITLE
build(api): Use relative import hack for Node v12

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -11,7 +11,12 @@
     "test": "yarn run lint"
   },
   "engines": {
-    "node": ">=13.2.0"
+    "node": "^12.17.0 || >=13.2.0"
+  },
+  "eslintConfig": {
+    "parserOptions": {
+      "sourceType": "module"
+    }
   },
   "dependencies": {
     "@ocd-cleanup/common": "*",

--- a/packages/api/rollup.config.js
+++ b/packages/api/rollup.config.js
@@ -4,24 +4,39 @@
  *
  * This script imports build constants from @ocd-cleanup/common, which is a
  * native ESM package.
- * Unfortunately, Rollup attempts to transpile this config file from ESM to CJS.
- * This causes Node.js to fail, because the transpiled (now CJS) config file
- * attempts to require() @ocd-cleanup/common (ESM)--which is impossible.
+ * Unfortunately, Rollup transpiles the config file from ESM to CJS before
+ * running it. The transpiled code (CJS) attempts to load @ocd-cleanup/common
+ * using require(), which fails because Node.js disallows loading ESM from CJS.
  *
- * The solution is to prevent Rollup from transpiling this config file before
- * passing it to Node.js. As of Rollup v2.44.0, the only way to do so is to:
+ * ## Solution 1
+ * Prevent Rollup from transpiling the config file before passing it to Node.js.
+ * As of Rollup v2.44.0, the only way to do so is to:
  *
- * 1. Use Node.js >= 13, and...
- * 2. Use the `.mjs` file extension for the config file.
- *    This is not great because TypeScript's compiler refuses to type-check .mjs
+ * 1. Use the `.mjs` file extension for the config file.
+ *    This is not ideal because TypeScript's compiler refuses to type-check .mjs
  *    files, meaning that we cannot automate type checks for our build config.
  *    Thankfully, VS Code still type-checks .mjs files.
+ * 2. Use Node.js >= 13.
+ *    Note that this is an arbitrary restriction imposed on by Rollup. Although
+ *    Node.js >= 12.17.0 can resolve `.mjs` files without a CLI flag, Rollup
+ *    does not know this.
  *
  * (See: https://rollupjs.org/guide/en/#using-untranspiled-config-files)
+ *
+ * ## Solution 2
+ * Alternatively, we can directly import the ESM code from @ocd-cleanup/common
+ * using a relative path. This allows Rollup to transpile the ESM.
+ *
+ * This allows us to keep the `.js` extension, and support Node.js v12.
+ * This is the hack will use until Node.js v12 reaches EOL or Rollup provides
+ * better native ESM support.
  */
 
 /* eslint-disable node/no-unpublished-import */
-import {RELAY_SCRIPT_FILE} from '@ocd-cleanup/common';
+/* eslint-disable node/no-unsupported-features/es-syntax */
+// Import @ocd-cleanup/common using a relative path. This is a hack, btw.
+// File extension is required to make this work in Node.js v12 AND v14.
+import {RELAY_SCRIPT_FILE} from '../common/build/src/index.js';
 import {nodeResolve} from '@rollup/plugin-node-resolve';
 import typescript from '@rollup/plugin-typescript';
 import copy from 'rollup-plugin-copy';


### PR DESCRIPTION
Make the Rollup config import @ocd-cleanup/common using a relative path. This allows Rollup to transpile all ESM code instead of making Node.js attempt to import ESM from CJS (which is impossible).

This hack provides two benefits:

- We can use Node.js v12 for development
- We can use the `.js` extension for the Rollup build script

Small changes were made in `package.json` to allow Node.js v12, and to make ESLint happy.