### PR TITLE
ci: Add Build & Lint workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,43 @@
+name: Build & Lint
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '12 15 10 * *'
+
+env:
+  default-node-version: 12
+
+jobs:
+  build:
+    # Fortunately, GitHub-hosted runners come preinstalled with Yarn.
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: ['12', '14', '16']
+        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: yarn install --frozen-lockfile
+      - run: yarn run build
+
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ env.default-node-version }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ env.default-node-version }}
+      - run: yarn install --frozen-lockfile
+      - run: yarn run lint

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "packages/*"
   ],
   "scripts": {
+    "build": "yarn run build:manager && yarn workspace @ocd-cleanup/e2e-tests build",
     "build:manager": "yarn workspace @ocd-cleanup/common build && yarn workspace @ocd-cleanup/api build && yarn workspace @ocd-cleanup/manager build",
     "lint": "eslint . && prettier --check ."
   },

--- a/packages/api/rollup.config.js
+++ b/packages/api/rollup.config.js
@@ -36,6 +36,7 @@
 /* eslint-disable node/no-unsupported-features/es-syntax */
 // Import @ocd-cleanup/common using a relative path. This is a hack, btw.
 // File extension is required to make this work in Node.js v12 AND v14.
+// eslint-disable-next-line node/no-missing-import
 import {RELAY_SCRIPT_FILE} from '../common/build/src/index.js';
 import {nodeResolve} from '@rollup/plugin-node-resolve';
 import typescript from '@rollup/plugin-typescript';


### PR DESCRIPTION
Now that we have lots of JavaScript/TypeScript code, a proper CI workflow for building/linting is in order.

I'm not sure this workflow is ready to be used as a mandatory status check for all future PRs. It would be sensible for a JS/TS-only repository, but we have ASH code that doesn't get checked by current tools.

The CI script is not optimized, either. Each package is currently built one at a time. Everything is rebuilt for any change, including non-code changes (e.g. documentation). No caching is done whatsoever. (We could look at tools like [Lerna](https://github.com/lerna/lerna) for some of these features, but I don't know if our project is large enough to warrant more tooling beyond what Yarn v1 already offers.)

For now, I suggest using this workflow only as a guide and not a requirement for merging PRs.

Note: I have a mind to migrate to NPM v7 as it seems to support workspaces as well. It would be a friendlier option for beginners, as well as _anecdotally_ being faster than Yarn on Windows.